### PR TITLE
[FEAT#3] 견석서 진단 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly  'org.mariadb.jdbc:mariadb-java-client:3.3.3'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.9"
+services:
+  mariadb:
+    image: mariadb:11
+    container_name: techon-mariadb
+    environment:
+      MARIADB_ROOT_PASSWORD: 8833
+      MARIADB_DATABASE: techon_maria_db
+      MARIADB_USER: app
+      MARIADB_PASSWORD: app1234
+    ports:
+      - "3307:3306"
+    command: ["--character-set-server=utf8mb4","--collation-server=utf8mb4_general_ci"]
+    volumes:
+      - mariadb_data:/var/lib/mysql
+volumes:
+  mariadb_data:

--- a/src/main/java/com/techon/server/domain/estimation/controller/EstimationController.java
+++ b/src/main/java/com/techon/server/domain/estimation/controller/EstimationController.java
@@ -1,0 +1,32 @@
+package com.techon.server.domain.estimation.controller;
+
+import com.techon.server.domain.estimation.dto.EstimationRequestDTO;
+import com.techon.server.domain.estimation.dto.EstimationResponseDTO;
+import com.techon.server.domain.estimation.entity.Estimation;
+import com.techon.server.domain.estimation.service.EstimationService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/estimation")
+public class EstimationController {
+
+    private final EstimationService estimationService;
+
+    @Operation(
+            summary = "견적서 진단 API",
+            description = "증상과 모델명, 카테고리(MOB(휴대폰/테블릿)/COM(노트북/PC)/APP(생활가전)/DEV(주변기기/기타))를 입력하면 진단 결과, 필요 부품, 견적(최소, 최대, 합본), 카테고리를 반환합니다."
+    )
+    @PostMapping()
+    public ResponseEntity<EstimationResponseDTO> estimate(
+            @RequestBody @Valid EstimationRequestDTO request) {
+        return ResponseEntity.ok(estimationService.analyze(request));
+    }
+}

--- a/src/main/java/com/techon/server/domain/estimation/dto/EstimationRequestDTO.java
+++ b/src/main/java/com/techon/server/domain/estimation/dto/EstimationRequestDTO.java
@@ -1,0 +1,11 @@
+package com.techon.server.domain.estimation.dto;
+
+import com.techon.server.domain.estimation.entity.Category;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record EstimationRequestDTO (
+        @NotBlank String text,
+        @NotBlank String modelName,
+        @NotNull Category category
+        ){}

--- a/src/main/java/com/techon/server/domain/estimation/dto/EstimationResponseDTO.java
+++ b/src/main/java/com/techon/server/domain/estimation/dto/EstimationResponseDTO.java
@@ -1,0 +1,21 @@
+package com.techon.server.domain.estimation.dto;
+
+import com.techon.server.domain.estimation.entity.Category;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record EstimationResponseDTO(
+        Long estimationId,
+        String diagnosis,
+        List<String> requiredParts,
+        Integer estimateMin,
+        Integer estimateMax,
+        String estimateRaw,
+        Category category,
+        List<String> matchedKeywords,
+        Integer score,
+
+        String normalizedText
+) {}

--- a/src/main/java/com/techon/server/domain/estimation/entity/Category.java
+++ b/src/main/java/com/techon/server/domain/estimation/entity/Category.java
@@ -1,0 +1,5 @@
+package com.techon.server.domain.estimation.entity;
+
+public enum Category {
+    MOB, COM, APP, DEV
+}

--- a/src/main/java/com/techon/server/domain/estimation/entity/Estimation.java
+++ b/src/main/java/com/techon/server/domain/estimation/entity/Estimation.java
@@ -1,0 +1,46 @@
+package com.techon.server.domain.estimation.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "estimation")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Estimation {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 모델명
+    private String modelExample;
+
+    // MOB/COM/APP/DEV
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 8)
+    private Category category;
+
+    // 증상 키워드 csv
+    @Column(nullable = false, length = 1000)
+    private String symptomKeywordsCsv;
+
+    // 진단 결과
+    @Column(nullable = false, length = 200)
+    private String diagnosis;
+
+    // 필요한 부품 csv
+    @Column(length = 500)
+    private String requiredPartsCsv;
+
+    // 견적 범위 원문
+    @Column(length = 100)
+    private String estimateRaw;
+
+    // 룰 우선순위 (겹칠 때 높은 값 우선)
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer priority = 0;
+}

--- a/src/main/java/com/techon/server/domain/estimation/repository/EstimationRepository.java
+++ b/src/main/java/com/techon/server/domain/estimation/repository/EstimationRepository.java
@@ -1,0 +1,11 @@
+package com.techon.server.domain.estimation.repository;
+
+import com.techon.server.domain.estimation.entity.Category;
+import com.techon.server.domain.estimation.entity.Estimation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EstimationRepository extends JpaRepository<Estimation, Long> {
+    List<Estimation> findByCategoryOrderByPriorityDescIdAsc(Category category);
+}

--- a/src/main/java/com/techon/server/domain/estimation/service/EstimationService.java
+++ b/src/main/java/com/techon/server/domain/estimation/service/EstimationService.java
@@ -1,0 +1,188 @@
+package com.techon.server.domain.estimation.service;
+
+import com.techon.server.domain.estimation.dto.EstimationRequestDTO;
+import com.techon.server.domain.estimation.dto.EstimationResponseDTO;
+import com.techon.server.domain.estimation.entity.Category;
+import com.techon.server.domain.estimation.entity.Estimation;
+import com.techon.server.domain.estimation.repository.EstimationRepository;
+import com.techon.server.domain.estimation.util.TextNormalizer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class EstimationService {
+
+    private final EstimationRepository estimationRepository;
+
+    private static final Map<String, List<String>> SYN = new HashMap<>() {{
+        put("화면", List.of("디스플레이","lcd","액정","패널","스크린"));
+        put("깨짐", List.of("파손","크랙","금감","금","균열","깨졌"));
+        put("액정", List.of("lcd","디스플레이","패널"));
+        put("터치", List.of("터치불가","터치 안됨","유령터치","touch","터치오류"));
+        put("불량", List.of("고장","오류","문제","이상"));
+        put("줄감", List.of("줄 감","줄이감","줄 무늬","줄생김","줄간섭","라인생김"));
+        put("전원", List.of("부팅","전원불가","전원안켜짐","꺼짐"));
+        put("배터리", List.of("충전","전지","배터리수명","배터리빨리닳"));
+        put("소음", List.of("팬소음","냉각팬","쿨링","윙윙"));
+    }};
+
+    private static final Set<String> JOSA = Set.of(
+            "이","가","은","는","을","를","도","만","요","이요","에요","이에요","네요","가요","인데","인데요","라","이라"
+    );
+
+    private static String tokenPattern(String t) {
+        // 토큰 + 조사 허용 (예: "불량", "불량이에요")
+        return Pattern.quote(t) + "(?:" + String.join("|", JOSA) + ")?";
+    }
+
+    private static int levenshtein(String a, String b) {
+        int n=a.length(), m=b.length();
+        if (n==0) return m; if (m==0) return n;
+        int[] prev=new int[m+1], cur=new int[m+1];
+        for (int j=0;j<=m;j++) prev[j]=j;
+        for (int i=1;i<=n;i++) {
+            cur[0]=i;
+            char ca=a.charAt(i-1);
+            for (int j=1;j<=m;j++) {
+                int cost = (ca==b.charAt(j-1))?0:1;
+                cur[j]=Math.min(Math.min(cur[j-1]+1, prev[j]+1), prev[j-1]+cost);
+            }
+            int[] tmp=prev; prev=cur; cur=tmp;
+        }
+        return prev[m];
+    }
+
+    private boolean flexibleHit(String normText, String kwNorm) {
+        String textNoSp = normText.replace(" ", "");
+        String keyNoSp  = kwNorm.replace(" ", "");
+        if (textNoSp.contains(keyNoSp)) return true; // "터치불량" vs "터치 불량"
+
+        String[] toks = kwNorm.split("\\s+");
+        // 1) 토큰 순서 유지, 사이 단어 허용: "터치.*불량"
+        if (toks.length >= 2) {
+            StringBuilder sb = new StringBuilder();
+            for (int i=0;i<toks.length;i++) {
+                if (i>0) sb.append(".*?");
+                sb.append(tokenPattern(toks[i]));
+            }
+            if (Pattern.compile(sb.toString()).matcher(normText).find()) return true;
+        }
+
+        // 2) 각 토큰이 텍스트 내에 (조사 허용으로) 존재하면 hit
+        boolean allPresent = true;
+        for (String tok : toks) {
+            String tp = tokenPattern(tok);
+            if (!Pattern.compile(tp).matcher(normText).find()) {
+                allPresent = false; break;
+            }
+        }
+        if (allPresent && toks.length > 0) return true;
+
+        // 3) 동의어 확장(토큰 단위)
+        for (String tok : toks) {
+            for (String syn : SYN.getOrDefault(tok, List.of())) {
+                String s = TextNormalizer.normalize(syn);
+                if (normText.contains(s) || normText.replace(" ","").contains(s.replace(" ",""))) {
+                    return true;
+                }
+            }
+        }
+
+        // 4) 오타 허용(레벤슈타인 <= 1): 텍스트 단어들과 비교
+        String[] words = normText.split("\\s+");
+        outer:
+        for (String tok : toks.length==0 ? new String[]{kwNorm} : toks) {
+            // 토큰 그대로 있으면 패스
+            if (normText.contains(tok)) continue;
+            for (String w : words) {
+                if (levenshtein(tok, w) <= 1) continue outer; // 토큰별 하나라도 가까우면 통과
+            }
+            return false; // 이 토큰은 너무 멀다
+        }
+        return true;
+    }
+
+    public EstimationResponseDTO analyze(EstimationRequestDTO request) {
+
+        Category category = request.category();
+        String norm = TextNormalizer.normalize(request.text());
+
+        List<Estimation> rules = estimationRepository.findByCategoryOrderByPriorityDescIdAsc(request.category());
+
+        Match best = null;
+        for (Estimation r : rules) {
+            Match m = score(norm, r);
+            if (m != null && (best == null || m.score > best.score)) best = m;
+        }
+
+        if (best == null) {
+            return EstimationResponseDTO.builder()
+                    .estimationId(null)
+                    .diagnosis(null)
+                    .requiredParts(List.of())
+                    .estimateMin(0).estimateMax(0).estimateRaw(null)
+                    .category(category)
+                    .matchedKeywords(List.of())
+                    .score(0)
+                    .normalizedText(norm)
+                    .build();
+        }
+        return EstimationResponseDTO.builder()
+                .estimationId(best.rule.getId())
+                .diagnosis(best.rule.getDiagnosis())
+                .requiredParts(TextNormalizer.csvToList(best.rule.getRequiredPartsCsv()))
+                .estimateRaw(best.rule.getEstimateRaw())
+                .estimateMin(best.estimate[0])
+                .estimateMax(best.estimate[1])
+                .category(category)
+                .matchedKeywords(best.matched)
+                .score(best.score)
+                .normalizedText(norm)
+                .build();
+    }
+
+    private Match score(String normText, Estimation rule) {
+        var kws = TextNormalizer.csvToList(rule.getSymptomKeywordsCsv());
+        if (kws.isEmpty()) return null;
+
+        int score = Optional.ofNullable(rule.getPriority()).orElse(0);
+        List<String> matched = new ArrayList<>();
+
+        for (String kw : kws) {
+            String nk = TextNormalizer.normalize(kw);
+            if (nk.isBlank()) continue;
+
+            boolean hit = contains(normText, nk);
+            if (!hit) {
+                for (String token : nk.split(" ")) {
+                    if (token.length() < 2) continue;
+                    for (String syn : SYN.getOrDefault(token, List.of())) {
+                        if (normText.contains(TextNormalizer.normalize(syn))) { hit = true; break; }
+                    }
+                    if (hit) break;
+                }
+            }
+            if (hit) {
+                matched.add(kw);
+                score += 10;
+                if (normText.contains(nk)) score += 5; // 완전 일치 보너스
+                else if (normText.replace(" ","").contains(nk.replace(" ",""))) score += 3; // 공백만 무시
+            }
+        }
+
+        if (matched.isEmpty()) return null;
+
+        int[] est = TextNormalizer.parseEstimateRange(rule.getEstimateRaw());
+        return new Match(rule, matched, score, est);
+    }
+
+    private boolean contains(String text, String kw) {
+        return text.contains(kw) || text.replace(" ", "").contains(kw.replace(" ", ""));
+    }
+
+    private record Match(Estimation rule, List<String> matched, int score, int[] estimate) {}
+}

--- a/src/main/java/com/techon/server/domain/estimation/util/TextNormalizer.java
+++ b/src/main/java/com/techon/server/domain/estimation/util/TextNormalizer.java
@@ -1,0 +1,39 @@
+package com.techon.server.domain.estimation.util;
+
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public final class TextNormalizer {
+
+    private static final Pattern NON_KO_ALNUM = Pattern.compile("[^0-9A-Za-z가-힣 ]+");
+
+    public static String normalize(String s) {
+        if (s == null) return "";
+        String t = Normalizer.normalize(s, Normalizer.Form.NFKC).toLowerCase(Locale.KOREAN);
+        t = NON_KO_ALNUM.matcher(t).replaceAll(" ");
+        t = t.replaceAll("\\s+", " ").trim();
+        return t;
+    }
+
+    public static List<String> csvToList(String csv) {
+        if (csv == null || csv.isBlank()) return List.of();
+        String[] arr = csv.split("\\s*,\\s*");
+        List<String> out = new ArrayList<>();
+        for (String a : arr) if (!a.isBlank()) out.add(a.trim());
+        return out;
+    }
+
+    public static int[] parseEstimateRange(String raw) {
+        if (raw == null) return new int[]{0,0};
+        String only = raw.replaceAll("[^0-9~\\-]", "");
+        String[] p = only.split("[~\\-]");
+        try {
+            if (p.length == 2) return new int[]{ Integer.parseInt(p[0]), Integer.parseInt(p[1]) };
+            if (p.length == 1) { int v = Integer.parseInt(p[0]); return new int[]{v, v}; }
+        } catch (NumberFormatException ignored) {}
+        return new int[]{0,0};
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,22 @@
 spring:
+  datasource:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://localhost:3307/techon_maria_db?useUnicode=true&characterEncoding=utf8
+    username: root
+    password: 8833
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MariaDBDialect
+        jdbc:
+          time_zone: Asia/Seoul
   mvc:
     pathmatch:
-          matching-strategy: ant_path_matcher
+      matching-strategy: ant_path_matcher
+
 app:
   kakao:
     rest-api-key: 4d0a7560edc72d30ac6350defe3e38eb


### PR DESCRIPTION
- 견적서 진단 API 구현

## #️⃣연관된 이슈
> #3 

## 📝작업 내용
> 증상과 모델명, 카테고리(MOB(휴대폰/테블릿)/COM(노트북/PC)/APP(생활가전)/DEV(주변기기/기타))를 입력하면 진단 결과, 필요 부품, 견적(최소, 최대, 합본), 카테고리를 반환

## 🔎코드 설명(스크린샷(선택))
> 코드에 대한 설명을 작성해주세요.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
